### PR TITLE
Added duplicate results on SARIG_wide output

### DIFF
--- a/pygeochemtools/geochem/transform.py
+++ b/pygeochemtools/geochem/transform.py
@@ -18,8 +18,13 @@ def long_to_wide(
     """Convert geochemical data tables from long to wide form.
 
     This function takes a dataframe of long form geochemical data, i.e. data with one
-    row per element, and converts it to a standard wide form data with one row per
-    sample and each element in a separate column.
+    row per element, and runs a pivot to convert it to a standard wide form data with
+    one row per sample and each element in a separate column.
+
+    It handles duplicate values based on sample_id and element_id by taking the first
+    duplicate value initially, then catching the second duplicate, performing a second
+    pivot, and appengind the duplicates to the final table. It does not handle duplicate
+    duplicates, in which case it will return only the first value.
 
     Args:
         df (pd.DataFrame): Dataframe containing long form data.
@@ -32,11 +37,13 @@ def long_to_wide(
 
     Returns:
         pd.DataFrame: Dataframe converted to wide table format with one sample per row
-        and columns for each element.
+        and columns for each element. Contains only sample_id and element/unit values.
     """
     df = df
-    df = df.drop_duplicates(subset=[sample_id, element_id])
+    # grab duplicate values
+    duplicate_df = df[df.duplicated(subset=[sample_id, element_id], keep="last")]
 
+    df = df.drop_duplicates(subset=[sample_id, element_id])
     if include_units:
         data = df.pivot(
             index=[sample_id], columns=element_id, values=[value]
@@ -60,6 +67,43 @@ def long_to_wide(
 
         df_wide = pd.concat([data, unit], axis=1)[c]
 
+        if not duplicate_df.empty:
+            try:
+                dup_data = duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=[value]
+                ).droplevel(0, axis=1)
+
+                dup_unit = (
+                    duplicate_df.pivot(
+                        index=[sample_id], columns=element_id, values=[units]
+                    )
+                    .add_suffix("_UNIT")
+                    .droplevel(0, axis=1)
+                )
+            except ValueError as e:
+                print(
+                    "There were duplicate duplicates. So no duplicates have been \
+                    included in the output",
+                    e,
+                )
+
+            else:
+                assert (
+                    dup_data.columns.size == dup_unit.columns.size
+                ), "pivoted column lengths aren't equal"
+
+                d = np.empty(
+                    (dup_data.columns.size + dup_unit.columns.size,), dtype=object,
+                )
+                d[0::2], d[1::2] = (
+                    dup_data.columns,
+                    dup_unit.columns,
+                )
+
+                dup_df_wide = pd.concat([dup_data, dup_unit], axis=1)[d]
+
+                df_wide = df_wide.append(dup_df_wide).sort_values(by=sample_id)
+
         return df_wide
 
     else:
@@ -67,7 +111,19 @@ def long_to_wide(
             index=[sample_id], columns=element_id, values=[value]
         ).droplevel(0, axis=1)
 
-        return data
+        if not duplicate_df.empty:
+            try:
+                dup_data = duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=[value]
+                ).droplevel(0, axis=1)
+            except ValueError as e:
+                print(
+                    "There were duplicate duplicates. So no duplicates have been \
+                    included in the output",
+                    e,
+                )
+
+        return data.append(dup_data).sort_values(by=sample_id)
 
 
 def sarig_methods_wide(
@@ -91,6 +147,8 @@ def sarig_methods_wide(
     """
     ...
     df = df
+    # grab duplicate values
+    duplicate_df = df[df.duplicated(subset=[sample_id, element_id], keep="last")]
     df = df.drop_duplicates(subset=[sample_id, element_id])
 
     method_code = (
@@ -137,5 +195,71 @@ def sarig_methods_wide(
     )
 
     df_wide = pd.concat([method_code, determination, digestion, fusion], axis=1)[c]
+
+    if not duplicate_df.empty:
+        try:
+            dup_method_code = (
+                duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=["CHEM_METHOD_CODE"],
+                )
+                .add_suffix("_METHOD_CODE")
+                .droplevel(0, axis=1)
+            )
+            dup_determination = (
+                duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=["DETERMINATION"],
+                )
+                .add_suffix("_DETERMINATION")
+                .droplevel(0, axis=1)
+            )
+            dup_digestion = (
+                duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=["DIGESTION"],
+                )
+                .add_suffix("_DIGESTION")
+                .droplevel(0, axis=1)
+            )
+            dup_fusion = (
+                duplicate_df.pivot(
+                    index=[sample_id], columns=element_id, values=["FUSION"],
+                )
+                .add_suffix("_FUSION")
+                .droplevel(0, axis=1)
+            )
+        except ValueError as e:
+            print(
+                "There were duplicate duplicates in the method list. \
+                So no duplicates have been included in the output",
+                e,
+            )
+        else:
+            assert (
+                dup_method_code.columns.size
+                == dup_determination.columns.size  # noqa: W503
+                == dup_digestion.columns.size  # noqa: W503
+                == dup_fusion.columns.size  # noqa: W503
+            ), "pivoted column lengths aren't equal"
+
+            d = np.empty(
+                (
+                    dup_method_code.columns.size
+                    + dup_determination.columns.size  # noqa: W503
+                    + dup_digestion.columns.size  # noqa: W503
+                    + dup_fusion.columns.size,  # noqa: W503
+                ),
+                dtype=object,
+            )
+            d[0::4], d[1::4], d[2::4], d[3::4] = (
+                dup_method_code.columns,
+                dup_determination.columns,
+                dup_digestion.columns,
+                dup_fusion.columns,
+            )
+
+            dup_df_wide = pd.concat(
+                [dup_method_code, dup_determination, dup_digestion, dup_fusion], axis=1
+            )[d]
+
+            df_wide = df_wide.append(dup_df_wide).sort_values(by=sample_id)
 
     return df_wide


### PR DESCRIPTION
Updated transform.py to handle duplicate elements in SARIG data. Takes the first value initially, then catching a second duplicate, pivoting those duplicates and then appending to the final table. Does not handle duplicate duplicates.

